### PR TITLE
build: get file name for top-level main package from git remote name

### DIFF
--- a/internal/command/build/build_test.go
+++ b/internal/command/build/build_test.go
@@ -19,9 +19,19 @@ type (
 		OutError  error
 	}
 
+	RemoteMock struct {
+		InName    string
+		OutDomain string
+		OutPath   string
+		OutError  error
+	}
+
 	MockGitService struct {
 		HEADIndex int
 		HEADMocks []HEADMock
+
+		RemoteIndex int
+		RemoteMocks []RemoteMock
 	}
 )
 
@@ -29,6 +39,13 @@ func (m *MockGitService) HEAD() (string, string, error) {
 	i := m.HEADIndex
 	m.HEADIndex++
 	return m.HEADMocks[i].OutHash, m.HEADMocks[i].OutBranch, m.HEADMocks[i].OutError
+}
+
+func (m *MockGitService) Remote(name string) (string, string, error) {
+	i := m.RemoteIndex
+	m.RemoteIndex++
+	m.RemoteMocks[i].InName = name
+	return m.RemoteMocks[i].OutDomain, m.RemoteMocks[i].OutPath, m.RemoteMocks[i].OutError
 }
 
 type (

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -41,12 +41,12 @@ var (
 	prereleaseRE = regexp.MustCompile(`^(v?([0-9]+)\.([0-9]+)\.([0-9]+))-([0-9]+)-g([0-9a-f]+)$`)
 )
 
-// PreflightChecklist is a list of preflight checks for commands.
+// PreflightChecklist is a list of common preflight checks for commands.
 type PreflightChecklist struct {
 	Go bool
 }
 
-// PreflightInfo is a list of preflight information for commands.
+// PreflightInfo is a list of common preflight information for commands.
 type PreflightInfo struct {
 	WorkingDirectory string
 	GoVersion        string

--- a/internal/command/release/release.go
+++ b/internal/command/release/release.go
@@ -148,6 +148,7 @@ func (c *Command) Help() string {
 }
 
 // Run runs the actual command with the given command-line arguments.
+// This method is used as a proxy for creating dependencies and the actual command execution is delegated to the run method for testing purposes.
 func (c *Command) Run(args []string) int {
 	git, err := git.New(".")
 	if err != nil {
@@ -155,7 +156,7 @@ func (c *Command) Run(args []string) int {
 		return command.GitError
 	}
 
-	// TODO: should we check for other remote names too?
+	// TODO: should we check for remote names other than origin?
 	domain, path, err := git.Remote(remoteName)
 	if err != nil {
 		c.ui.Error(err.Error())

--- a/internal/command/semver/semver.go
+++ b/internal/command/semver/semver.go
@@ -62,6 +62,7 @@ func (c *Command) Help() string {
 }
 
 // Run runs the actual command with the given command-line arguments.
+// This method is used as a proxy for creating dependencies and the actual command execution is delegated to the run method for testing purposes.
 func (c *Command) Run(args []string) int {
 	git, err := git.New(".")
 	if err != nil {

--- a/internal/command/update/update.go
+++ b/internal/command/update/update.go
@@ -65,6 +65,7 @@ func (c *Command) Help() string {
 }
 
 // Run runs the actual command with the given command-line arguments.
+// This method is used as a proxy for creating dependencies and the actual command execution is delegated to the run method for testing purposes.
 func (c *Command) Run(args []string) int {
 	// If no access token is provided, we try without it!
 	token := os.Getenv("GELATO_GITHUB_TOKEN")


### PR DESCRIPTION
## Description

For **build** command, when there is a `main.go` file in top-level directory, the name of binary will be implied from remote git repository name instead of the working directory path.

### Checklist

  - [x] PR title is clear and describes the work
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Unit tests are provided for the new change
