### PR TITLE
decorate: kickstart

### DIFF
--- a/cmd/gelato/main.go
+++ b/cmd/gelato/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/moorara/gelato/internal/command"
 	"github.com/moorara/gelato/internal/command/build"
+	"github.com/moorara/gelato/internal/command/decorate"
 	"github.com/moorara/gelato/internal/command/release"
 	"github.com/moorara/gelato/internal/command/semver"
 	"github.com/moorara/gelato/internal/command/update"
@@ -54,6 +55,9 @@ func main() {
 		},
 		"update": func() (cli.Command, error) {
 			return update.NewCommand(ui)
+		},
+		"decorate": func() (cli.Command, error) {
+			return decorate.NewCommand(ui, spec.App)
 		},
 	}
 

--- a/go.sum
+++ b/go.sum
@@ -46,7 +46,6 @@ github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uP
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/huandu/xstrings v1.3.2 h1:L18LIDzqlW6xN2rEkpdV8+oL/IXWJ1APd+vsdYy4Wdw=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
-github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.11 h1:3tnifQM4i+fbajXKBHXWEH+KvNHqojZ778UH75j3bGA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
@@ -99,7 +98,6 @@ github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 golang.org/x/crypto v0.0.0-20190219172222-a4c6cb3142f2/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073 h1:xMPOj6Pz6UipU1wXLkrtqpHbR0AVFnyPEQq/wRWz9lM=
 golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a h1:vclmkQCjlDX5OydZ9wv8rBCcS0QyQY66Mpf/7BZbInM=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -126,7 +124,6 @@ gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -31,6 +31,8 @@ const (
 	GitHubError
 	// ChangelogError is the exit code when generating the changelog fails.
 	ChangelogError
+	// DecorationError is the exit code when decorating an application fails.
+	DecorationError
 	// UnsupportedError is the exit code when a capability is not supported.
 	UnsupportedError
 	// MiscError is the exit code when a miscellaneous operation fails.

--- a/internal/command/decorate/decorate.go
+++ b/internal/command/decorate/decorate.go
@@ -1,0 +1,108 @@
+package decorate
+
+import (
+	"context"
+	"flag"
+	"time"
+
+	"github.com/mitchellh/cli"
+
+	"github.com/moorara/gelato/internal/command"
+	"github.com/moorara/gelato/internal/decorate"
+	"github.com/moorara/gelato/internal/spec"
+)
+
+const (
+	decorateTimeout  = time.Minute
+	decorateSynopsis = `[WIP] Decorate an application`
+	decorateHelp     = `
+  Use this command for creating a decorated version of an application.
+  Currently, this command can only decorate Go applications.
+
+  A decorator decorates existing code blocks (packages, types, and functions) with extra capabilities.
+  Decorators can be used for augmenting an applications with a whole range of different functionalities.
+  They can be used for instrumenting an application, enabling observability, improving resiliency and reliability, hardening security, etc.
+
+  Usage:  gelato decorate
+
+  Examples:
+    gelato decorate
+  `
+)
+
+type decoratorService interface {
+	Decorate(string) error
+}
+
+// Command is the cli.Command implementation for decorate command.
+type Command struct {
+	ui       cli.Ui
+	spec     spec.App
+	services struct {
+		decorator decoratorService
+	}
+}
+
+// NewCommand creates a decorate command.
+func NewCommand(ui cli.Ui, spec spec.App) (*Command, error) {
+	return &Command{
+		ui:   ui,
+		spec: spec,
+	}, nil
+}
+
+// Synopsis returns a short one-line synopsis of the command.
+func (c *Command) Synopsis() string {
+	return decorateSynopsis
+}
+
+// Help returns a long help text including usage, description, and list of flags for the command.
+func (c *Command) Help() string {
+	return decorateHelp
+}
+
+// Run runs the actual command with the given command-line arguments.
+// This method is used as a proxy for creating dependencies and the actual command execution is delegated to the run method for testing purposes.
+func (c *Command) Run(args []string) int {
+	decorator := decorate.New()
+	c.services.decorator = decorator
+
+	return c.run(args)
+}
+
+// run in an auxiliary method, so we can test the business logic with mock dependencies.
+func (c *Command) run(args []string) int {
+	fs := flag.NewFlagSet("decorate", flag.ContinueOnError)
+	fs.Usage = func() {
+		c.ui.Output(c.Help())
+	}
+
+	if err := fs.Parse(args); err != nil {
+		return command.FlagError
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), decorateTimeout)
+	defer cancel()
+
+	// ==============================> RUN PREFLIGHT CHECKS <==============================
+
+	checklist := command.PreflightChecklist{}
+
+	info, err := command.RunPreflightChecks(ctx, checklist)
+	if err != nil {
+		c.ui.Error(err.Error())
+		return command.PreflightError
+	}
+
+	// ==============================> DECORATE <==============================
+
+	err = c.services.decorator.Decorate(info.Context.WorkingDirectory)
+	if err != nil {
+		c.ui.Error(err.Error())
+		return command.DecorationError
+	}
+
+	// ==============================> DONE <==============================
+
+	return command.Success
+}

--- a/internal/command/decorate/decorate_test.go
+++ b/internal/command/decorate/decorate_test.go
@@ -1,0 +1,115 @@
+package decorate
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/moorara/gelato/internal/command"
+	"github.com/moorara/gelato/internal/spec"
+)
+
+type (
+	DecorateMock struct {
+		InPath   string
+		OutError error
+	}
+
+	MockDecoratorService struct {
+		DecorateIndex int
+		DecorateMocks []DecorateMock
+	}
+)
+
+func (m *MockDecoratorService) Decorate(path string) error {
+	i := m.DecorateIndex
+	m.DecorateIndex++
+	m.DecorateMocks[i].InPath = path
+	return m.DecorateMocks[i].OutError
+}
+
+func TestNewCommand(t *testing.T) {
+	ui := new(cli.MockUi)
+	spec := spec.App{}
+	c, err := NewCommand(ui, spec)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, c)
+}
+
+func TestCommand_Synopsis(t *testing.T) {
+	c := &Command{}
+	synopsis := c.Synopsis()
+
+	assert.NotEmpty(t, synopsis)
+}
+
+func TestCommand_Help(t *testing.T) {
+	c := &Command{}
+	help := c.Help()
+
+	assert.NotEmpty(t, help)
+}
+
+func TestCommand_Run(t *testing.T) {
+	c := &Command{ui: new(cli.MockUi)}
+	c.Run([]string{"--undefined"})
+
+	assert.NotNil(t, c.services.decorator)
+}
+
+func TestCommand_run(t *testing.T) {
+	tests := []struct {
+		name             string
+		spec             spec.App
+		decorator        *MockDecoratorService
+		args             []string
+		expectedExitCode int
+	}{
+		{
+			name:             "UndefinedFlag",
+			spec:             spec.App{},
+			args:             []string{"--undefined"},
+			expectedExitCode: command.FlagError,
+		},
+		{
+			name: "DecorateFails",
+			spec: spec.App{},
+			decorator: &MockDecoratorService{
+				DecorateMocks: []DecorateMock{
+					{OutError: errors.New("decoration error")},
+				},
+			},
+			args:             []string{},
+			expectedExitCode: command.DecorationError,
+		},
+		{
+			name: "Success",
+			spec: spec.App{},
+			decorator: &MockDecoratorService{
+				DecorateMocks: []DecorateMock{
+					{OutError: nil},
+				},
+			},
+			args:             []string{},
+			expectedExitCode: command.Success,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Command{
+				ui:   new(cli.MockUi),
+				spec: tc.spec,
+			}
+
+			c.services.decorator = tc.decorator
+
+			exitCode := c.run(tc.args)
+
+			assert.Equal(t, tc.expectedExitCode, exitCode)
+		})
+	}
+}

--- a/internal/decorate/decorate.go
+++ b/internal/decorate/decorate.go
@@ -1,0 +1,20 @@
+package decorate
+
+import (
+	"github.com/moorara/color"
+)
+
+// Decorator decorates a Go application.
+type Decorator struct {
+}
+
+// New creates a new decorator.
+func New() *Decorator {
+	return &Decorator{}
+}
+
+// Decorate decorates a Go application.
+func (d *Decorator) Decorate(path string) error {
+	color.White("Decorating ...")
+	return nil
+}

--- a/internal/decorate/decorate_test.go
+++ b/internal/decorate/decorate_test.go
@@ -1,0 +1,37 @@
+package decorate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+	d := New()
+
+	assert.NotNil(t, d)
+}
+
+func TestDecorator_Decorate(t *testing.T) {
+	tests := []struct {
+		name          string
+		path          string
+		expectedError error
+	}{
+		{
+			name:          "OK",
+			path:          ".",
+			expectedError: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d := &Decorator{}
+
+			err := d.Decorate(tc.path)
+
+			assert.Equal(t, tc.expectedError, err)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Add a new command for decorating applications (`decorate`).
This command is an **interim** command and **work-in-progress**.
Eventually, It will be removed and converted to a flag (`-decorate`) for the `build` command.

### Checklist

  - [x] PR title is clear and describes the work
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Unit tests are provided for the new change
