### PR TITLE
Decorate create dirs

### DIFF
--- a/internal/command/decorate/decorate_test.go
+++ b/internal/command/decorate/decorate_test.go
@@ -8,11 +8,13 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/moorara/gelato/internal/command"
+	"github.com/moorara/gelato/internal/log"
 	"github.com/moorara/gelato/internal/spec"
 )
 
 type (
 	DecorateMock struct {
+		InLevel  log.Level
 		InPath   string
 		OutError error
 	}
@@ -23,9 +25,10 @@ type (
 	}
 )
 
-func (m *MockDecoratorService) Decorate(path string) error {
+func (m *MockDecoratorService) Decorate(level log.Level, path string) error {
 	i := m.DecorateIndex
 	m.DecorateIndex++
+	m.DecorateMocks[i].InLevel = level
 	m.DecorateMocks[i].InPath = path
 	return m.DecorateMocks[i].OutError
 }
@@ -86,14 +89,58 @@ func TestCommand_run(t *testing.T) {
 			expectedExitCode: command.DecorationError,
 		},
 		{
-			name: "Success",
+			name: "Success_Trace",
 			spec: spec.App{},
 			decorator: &MockDecoratorService{
 				DecorateMocks: []DecorateMock{
 					{OutError: nil},
 				},
 			},
-			args:             []string{},
+			args:             []string{"-trace"},
+			expectedExitCode: command.Success,
+		},
+		{
+			name: "Success_Debug",
+			spec: spec.App{},
+			decorator: &MockDecoratorService{
+				DecorateMocks: []DecorateMock{
+					{OutError: nil},
+				},
+			},
+			args:             []string{"-debug"},
+			expectedExitCode: command.Success,
+		},
+		{
+			name: "Success_Info",
+			spec: spec.App{},
+			decorator: &MockDecoratorService{
+				DecorateMocks: []DecorateMock{
+					{OutError: nil},
+				},
+			},
+			args:             []string{"-info"},
+			expectedExitCode: command.Success,
+		},
+		{
+			name: "Success_Warn",
+			spec: spec.App{},
+			decorator: &MockDecoratorService{
+				DecorateMocks: []DecorateMock{
+					{OutError: nil},
+				},
+			},
+			args:             []string{"-warn"},
+			expectedExitCode: command.Success,
+		},
+		{
+			name: "Success_Error",
+			spec: spec.App{},
+			decorator: &MockDecoratorService{
+				DecorateMocks: []DecorateMock{
+					{OutError: nil},
+				},
+			},
+			args:             []string{"-error"},
 			expectedExitCode: command.Success,
 		},
 	}

--- a/internal/decorate/decorate.go
+++ b/internal/decorate/decorate.go
@@ -1,9 +1,15 @@
 package decorate
 
 import (
+	"go/parser"
+	"go/token"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/moorara/color"
+
+	"github.com/moorara/gelato/internal/log"
 )
 
 const (
@@ -12,11 +18,29 @@ const (
 
 // Decorator decorates a Go application.
 type Decorator struct {
+	loggers struct {
+		red     log.Logger
+		green   log.Logger
+		yellow  log.Logger
+		blue    log.Logger
+		magenta log.Logger
+		cyan    log.Logger
+		white   log.Logger
+	}
 }
 
 // New creates a new decorator.
 func New() *Decorator {
-	return &Decorator{}
+	d := &Decorator{}
+	d.loggers.red = log.NewColored(log.None, color.New(color.FgRed))
+	d.loggers.green = log.NewColored(log.None, color.New(color.FgGreen))
+	d.loggers.yellow = log.NewColored(log.None, color.New(color.FgYellow))
+	d.loggers.blue = log.NewColored(log.None, color.New(color.FgBlue))
+	d.loggers.magenta = log.NewColored(log.None, color.New(color.FgMagenta))
+	d.loggers.cyan = log.NewColored(log.None, color.New(color.FgCyan))
+	d.loggers.white = log.NewColored(log.None, color.New(color.FgWhite))
+
+	return d
 }
 
 func (d *Decorator) directories(basePath, relPath string, visit func(string, string) error) error {
@@ -43,17 +67,47 @@ func (d *Decorator) directories(basePath, relPath string, visit func(string, str
 }
 
 // Decorate decorates a Go application.
-func (d *Decorator) Decorate(path string) error {
+func (d *Decorator) Decorate(level log.Level, path string) error {
+	// Update loggers
+	d.loggers.red.SetLevel(level)
+	d.loggers.green.SetLevel(level)
+	d.loggers.yellow.SetLevel(level)
+	d.loggers.blue.SetLevel(level)
+	d.loggers.magenta.SetLevel(level)
+	d.loggers.cyan.SetLevel(level)
+	d.loggers.white.SetLevel(level)
+
 	// Sanitize the path
 	if _, err := os.Stat(path); err != nil {
 		return err
 	}
+
+	d.loggers.white.Infof("Decorating ...")
 
 	return d.directories(path, ".", func(basePath, relPath string) error {
 		// Creating a new directory for the decorated package
 		newDir := filepath.Join(basePath, decoratedDir, relPath)
 		if err := os.MkdirAll(newDir, os.ModePerm); err != nil {
 			return err
+		}
+		d.loggers.blue.Tracef("  Directory created: %s", newDir)
+
+		// Parse all Go packages and files in the currecnt directory
+		fset := token.NewFileSet()
+		pkgDir := filepath.Join(basePath, relPath)
+		d.loggers.cyan.Debugf("  Parsing directory: %s", pkgDir)
+		pkgs, err := parser.ParseDir(fset, pkgDir, nil, parser.AllErrors)
+		if err != nil {
+			return err
+		}
+		d.loggers.cyan.Tracef("  Directory parsed: %s", pkgDir)
+
+		// Visit all parsed Go files in the currecnt directory
+		for _, pkg := range pkgs {
+			d.loggers.yellow.Debugf("     Package: %s", pkg.Name)
+			for name, _ := range pkg.Files {
+				d.loggers.green.Debugf("      File: %s", name)
+			}
 		}
 
 		return nil

--- a/internal/decorate/decorate.go
+++ b/internal/decorate/decorate.go
@@ -1,7 +1,13 @@
 package decorate
 
 import (
-	"github.com/moorara/color"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+const (
+	decoratedDir = ".build"
 )
 
 // Decorator decorates a Go application.
@@ -13,8 +19,43 @@ func New() *Decorator {
 	return &Decorator{}
 }
 
+func (d *Decorator) directories(basePath, relPath string, visit func(string, string) error) error {
+	if err := visit(basePath, relPath); err != nil {
+		return err
+	}
+
+	dir := filepath.Join(basePath, relPath)
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+
+	for _, file := range files {
+		if file.IsDir() && file.Name() != decoratedDir {
+			subdir := filepath.Join(relPath, file.Name())
+			if err := d.directories(basePath, subdir, visit); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
 // Decorate decorates a Go application.
 func (d *Decorator) Decorate(path string) error {
-	color.White("Decorating ...")
-	return nil
+	// Sanitize the path
+	if _, err := os.Stat(path); err != nil {
+		return err
+	}
+
+	return d.directories(path, ".", func(basePath, relPath string) error {
+		// Creating a new directory for the decorated package
+		newDir := filepath.Join(basePath, decoratedDir, relPath)
+		if err := os.MkdirAll(newDir, os.ModePerm); err != nil {
+			return err
+		}
+
+		return nil
+	})
 }

--- a/internal/decorate/decorate_test.go
+++ b/internal/decorate/decorate_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/moorara/gelato/internal/log"
 )
 
 func TestNew(t *testing.T) {
@@ -17,6 +19,7 @@ func TestNew(t *testing.T) {
 func TestDecorator_Decorate(t *testing.T) {
 	tests := []struct {
 		name          string
+		level         log.Level
 		path          string
 		expectedError string
 	}{
@@ -34,12 +37,12 @@ func TestDecorator_Decorate(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			d := &Decorator{}
+			d := New()
 
 			// Clean-up
 			defer os.RemoveAll(filepath.Join(tc.path, decoratedDir))
 
-			err := d.Decorate(tc.path)
+			err := d.Decorate(tc.level, tc.path)
 
 			if tc.expectedError == "" {
 				assert.NoError(t, err)

--- a/internal/decorate/decorate_test.go
+++ b/internal/decorate/decorate_test.go
@@ -1,6 +1,8 @@
 package decorate
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,12 +18,17 @@ func TestDecorator_Decorate(t *testing.T) {
 	tests := []struct {
 		name          string
 		path          string
-		expectedError error
+		expectedError string
 	}{
 		{
-			name:          "OK",
-			path:          ".",
-			expectedError: nil,
+			name:          "PathNotExist",
+			path:          "/invalid/path",
+			expectedError: "stat /invalid/path: no such file or directory",
+		},
+		{
+			name:          "Success",
+			path:          "./test",
+			expectedError: "",
 		},
 	}
 
@@ -29,9 +36,16 @@ func TestDecorator_Decorate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			d := &Decorator{}
 
+			// Clean-up
+			defer os.RemoveAll(filepath.Join(tc.path, decoratedDir))
+
 			err := d.Decorate(tc.path)
 
-			assert.Equal(t, tc.expectedError, err)
+			if tc.expectedError == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tc.expectedError)
+			}
 		})
 	}
 }

--- a/internal/decorate/test/horizontal/main.go
+++ b/internal/decorate/test/horizontal/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, World!")
+}

--- a/internal/decorate/test/vertical/main.go
+++ b/internal/decorate/test/vertical/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, World!")
+}

--- a/internal/decorate/visitor.go
+++ b/internal/decorate/visitor.go
@@ -1,0 +1,34 @@
+package decorate
+
+import (
+	"go/ast"
+	"strings"
+)
+
+type visitor struct {
+	depth   int
+	loggers *loggers
+}
+
+func (v *visitor) Visit(n ast.Node) ast.Visitor {
+	if n == nil {
+		return nil
+	}
+
+	indent := strings.Repeat("  ", v.depth)
+	v.loggers.yellow.Tracef("%s%T", indent, n)
+
+	switch n := n.(type) {
+	case *ast.GenDecl:
+	case *ast.FuncDecl:
+	case *ast.Ident:
+		v.loggers.red.Debugf("%s  %s", indent, n.Name)
+	case *ast.ImportSpec:
+		v.loggers.red.Debugf("%s  %s", indent, n.Path.Value)
+	}
+
+	return &visitor{
+		depth:   v.depth + 1,
+		loggers: v.loggers,
+	}
+}

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,0 +1,179 @@
+package log
+
+import (
+	"log"
+	"os"
+	"sync"
+
+	"github.com/moorara/color"
+)
+
+// Level is the logging verbosity level.
+type Level int
+
+const (
+	// Trace shows logs in all levels.
+	Trace Level = iota
+	// Debug shows logs in Debug, Info, Warn, Error, and Fatal levels.
+	Debug
+	// Info shows logs in Info, Warn, Error, and Fatal levels.
+	Info
+	// Warn shows logs in Warn, Error, and Fatal levels.
+	Warn
+	// Error shows logs in Error and Fatal levels.
+	Error
+	// Fatal shows logs in Fatal level.
+	Fatal
+	// None does not show any logs.
+	None
+)
+
+// Logger is the interface for a simple logger.
+type Logger interface {
+	GetLevel() Level
+	SetLevel(l Level)
+	Tracef(format string, v ...interface{})
+	Debugf(format string, v ...interface{})
+	Infof(format string, v ...interface{})
+	Warnf(format string, v ...interface{})
+	Errorf(format string, v ...interface{})
+	Fatalf(format string, v ...interface{})
+}
+
+// logger implements the Logger interface for logging to standard output.
+type logger struct {
+	sync.Mutex
+	level  Level
+	logger *log.Logger
+}
+
+// New creates a new logger.
+func New(level Level) Logger {
+	return &logger{
+		level:  level,
+		logger: log.New(os.Stdout, "", 0),
+	}
+}
+
+func (l *logger) GetLevel() Level {
+	l.Mutex.Lock()
+	defer l.Mutex.Unlock()
+
+	return l.level
+}
+
+func (l *logger) SetLevel(level Level) {
+	l.Mutex.Lock()
+	defer l.Mutex.Unlock()
+
+	l.level = level
+}
+
+func (l *logger) Tracef(format string, v ...interface{}) {
+	l.Mutex.Lock()
+	defer l.Mutex.Unlock()
+
+	if l.level <= Trace {
+		l.logger.Printf(format, v...)
+	}
+}
+
+func (l *logger) Debugf(format string, v ...interface{}) {
+	l.Mutex.Lock()
+	defer l.Mutex.Unlock()
+
+	if l.level <= Debug {
+		l.logger.Printf(format, v...)
+	}
+}
+
+func (l *logger) Infof(format string, v ...interface{}) {
+	l.Mutex.Lock()
+	defer l.Mutex.Unlock()
+
+	if l.level <= Info {
+		l.logger.Printf(format, v...)
+	}
+}
+
+func (l *logger) Warnf(format string, v ...interface{}) {
+	l.Mutex.Lock()
+	defer l.Mutex.Unlock()
+
+	if l.level <= Warn {
+		l.logger.Printf(format, v...)
+	}
+}
+
+func (l *logger) Errorf(format string, v ...interface{}) {
+	l.Mutex.Lock()
+	defer l.Mutex.Unlock()
+
+	if l.level <= Error {
+		l.logger.Printf(format, v...)
+	}
+}
+
+func (l *logger) Fatalf(format string, v ...interface{}) {
+	l.Mutex.Lock()
+	defer l.Mutex.Unlock()
+
+	if l.level <= Fatal {
+		l.logger.Printf(format, v...)
+	}
+}
+
+// coloredLogger implements the Logger interface for logging to standard output with a color.
+type coloredLogger struct {
+	logger *logger
+	color  *color.Color
+}
+
+// NewColored creates a new colored logger.
+func NewColored(level Level, color *color.Color) Logger {
+	return &coloredLogger{
+		logger: &logger{
+			level:  level,
+			logger: log.New(os.Stdout, "", 0),
+		},
+		color: color,
+	}
+}
+
+func (l *coloredLogger) GetLevel() Level {
+	return l.logger.GetLevel()
+}
+
+func (l *coloredLogger) SetLevel(level Level) {
+	l.logger.SetLevel(level)
+}
+
+func (l *coloredLogger) Tracef(format string, v ...interface{}) {
+	msg := l.color.Sprintf(format, v...)
+	l.logger.Tracef(msg)
+}
+
+func (l *coloredLogger) Debugf(format string, v ...interface{}) {
+	msg := l.color.Sprintf(format, v...)
+	l.logger.Debugf(msg)
+}
+
+func (l *coloredLogger) Infof(format string, v ...interface{}) {
+	msg := l.color.Sprintf(format, v...)
+	l.logger.Infof(msg)
+}
+
+func (l *coloredLogger) Warnf(format string, v ...interface{}) {
+	msg := l.color.Sprintf(format, v...)
+	l.logger.Warnf(msg)
+}
+
+func (l *coloredLogger) Errorf(format string, v ...interface{}) {
+	msg := l.color.Sprintf(format, v...)
+	l.logger.Errorf(msg)
+}
+
+func (l *coloredLogger) Fatalf(format string, v ...interface{}) {
+	msg := l.color.Sprintf(format, v...)
+	l.logger.Fatalf(msg)
+}

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -1,0 +1,72 @@
+package log
+
+import (
+	"testing"
+
+	"github.com/moorara/color"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogger(t *testing.T) {
+	tests := []struct {
+		name   string
+		level  Level
+		format string
+		args   []interface{}
+	}{
+		{
+			name:   "Trace",
+			level:  Trace,
+			format: "foo: %s",
+			args:   []interface{}{"bar"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			l := New(None)
+
+			l.SetLevel(tc.level)
+			level := l.GetLevel()
+			assert.Equal(t, tc.level, level)
+
+			l.Tracef(tc.format, tc.args...)
+			l.Debugf(tc.format, tc.args...)
+			l.Infof(tc.format, tc.args...)
+			l.Warnf(tc.format, tc.args...)
+			l.Errorf(tc.format, tc.args...)
+		})
+	}
+}
+
+func TestColoredLogger(t *testing.T) {
+	tests := []struct {
+		name   string
+		level  Level
+		format string
+		args   []interface{}
+	}{
+		{
+			name:   "Trace",
+			level:  Trace,
+			format: "foo: %s",
+			args:   []interface{}{"bar"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			l := NewColored(None, color.New(color.FgWhite))
+
+			l.SetLevel(tc.level)
+			level := l.GetLevel()
+			assert.Equal(t, tc.level, level)
+
+			l.Tracef(tc.format, tc.args...)
+			l.Debugf(tc.format, tc.args...)
+			l.Infof(tc.format, tc.args...)
+			l.Warnf(tc.format, tc.args...)
+			l.Errorf(tc.format, tc.args...)
+		})
+	}
+}


### PR DESCRIPTION
## Description

  - [x] `decorate` creates `.build` directory with same structure as the top-level directory
  - [x] `decorate` command visits all nodes in _AST_ for non-test files in all packages

### Checklist

  - [x] PR title is clear and describes the work
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Unit tests are provided for the new change
