### PR TITLE
build: default name for top-level main package is directory name

### DIFF
--- a/internal/command/build/build.go
+++ b/internal/command/build/build.go
@@ -266,7 +266,7 @@ func (c *Command) run(args []string) int {
 	// We also assume the current directory is a main package if it contains a main.go file.
 	if _, err = os.Stat("./main.go"); err == nil {
 		mainPkg := "."
-		output := binPath + filepath.Base(info.Git.Remote.Path)
+		output := binPath + filepath.Base(info.Context.WorkingDirectory)
 
 		if err := c.buildAll(ctx, ldFlags, mainPkg, output); err != nil {
 			c.ui.Error(err.Error())

--- a/internal/command/update/update.go
+++ b/internal/command/update/update.go
@@ -121,6 +121,7 @@ func (c *Command) run(args []string) int {
 
 	binPath, err := exec.LookPath(os.Args[0])
 	if err != nil {
+		fmt.Println(err)
 		c.ui.Error(fmt.Sprintf("Cannot find the path for Gelato binary: %s", err))
 		return command.OSError
 	}

--- a/internal/command/update/update.go
+++ b/internal/command/update/update.go
@@ -121,7 +121,6 @@ func (c *Command) run(args []string) int {
 
 	binPath, err := exec.LookPath(os.Args[0])
 	if err != nil {
-		fmt.Println(err)
 		c.ui.Error(fmt.Sprintf("Cannot find the path for Gelato binary: %s", err))
 		return command.OSError
 	}

--- a/internal/command/update/update_test.go
+++ b/internal/command/update/update_test.go
@@ -108,6 +108,46 @@ func TestCommand_run(t *testing.T) {
 			args:             []string{},
 			expectedExitCode: command.GitHubError,
 		},
+		/* {
+			name: "DownloadReleaseAssetFails",
+			repo: &MockRepoService{
+				LatestReleaseMocks: []LatestReleaseMock{
+					{
+						OutRelease: &github.Release{
+							Name:    "1.0.0",
+							TagName: "v1.0.0",
+						},
+						OutResponse: &github.Response{},
+					},
+				},
+				DownloadReleaseAssetMocks: []DownloadReleaseAssetMock{
+					{OutError: errors.New("error on downloading the release asset")},
+				},
+			},
+			args:             []string{},
+			expectedExitCode: command.GitHubError,
+		},
+		{
+			name: "Success",
+			repo: &MockRepoService{
+				LatestReleaseMocks: []LatestReleaseMock{
+					{
+						OutRelease: &github.Release{
+							Name:    "1.0.0",
+							TagName: "v1.0.0",
+						},
+						OutResponse: &github.Response{},
+					},
+				},
+				DownloadReleaseAssetMocks: []DownloadReleaseAssetMock{
+					{
+						OutResponse: &github.Response{},
+					},
+				},
+			},
+			args:             []string{},
+			expectedExitCode: command.Success,
+		}, */
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Description

  - [x] The default binary name for top-level main package is now the directory name

### Checklist

  - [x] PR title is clear and describes the work
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Unit tests are provided for the new change
